### PR TITLE
add support for private certificate passphrase

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class JWTToken {
   */
   constructor() {
     this.privateCert = null;
+    this.privateCertPassphrase = null;
     this.publicCert = null;
     this.options = {
       accessTokenExpirationInSeconds: 3600,
@@ -50,11 +51,14 @@ class JWTToken {
   * @param {string} publicCertPath - path to public certificate
   * @return {object} promise -
   */
-  loadCerts(privateCertPath, publicCertPath) {
+  loadCerts(privateCertPath, publicCertPath, privateCertPassphrase) {
     return new Promise((resolve, reject) => {
       try {
         if (privateCertPath) {
           this.privateCert = fs.readFileSync(privateCertPath);
+        }
+        if (privateCertPassphrase) {
+          this.privateCertPassphrase = privateCertPassphrase;
         }
         if (publicCertPath) {
           this.publicCert = fs.readFileSync(publicCertPath);
@@ -107,7 +111,8 @@ class JWTToken {
         iat: nowSeconds,
         exp: nowSeconds + offsetSeconds
       });
-      jwt.sign(payload, this.privateCert, {algorithm: 'RS256'}, (err, token) => {
+      let cert = {key: this.privateCert, passphrase: this.privateCertPassphrase}
+      jwt.sign(payload, cert, { algorithm: 'RS256' }, (err, token) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
added support for private certificates that are encrypted with a passphrase. This is a feature built-in to jsonwebtoken.