### PR TITLE
Use truly async fs operations instead of sync event loop blocking io

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,20 +47,14 @@ class JWTToken {
   * @param {string} publicCertPath - path to public certificate
   * @return {object} promise -
   */
-  loadCerts(privateCertPath, publicCertPath) {
-    return new Promise((resolve, reject) => {
-      try {
-        if (privateCertPath) {
-          this.privateCert = fs.readFileSync(privateCertPath);
-        }
-        if (publicCertPath) {
-          this.publicCert = fs.readFileSync(publicCertPath);
-        }
-        resolve(true);
-      } catch (e) {
-        reject(e);
-      }
-    });
+  async loadCerts(privateCertPath, publicCertPath) {
+    if (privateCertPath) {
+      this.privateCert = await fs.readFile(privateCertPath);
+    }
+    if (publicCertPath) {
+      this.publicCert = await fs.readFile(publicCertPath);
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
It does not make any sense to use sync io functions inside a Promise as it will anyway block the event loop without any benefit
Async fs module functions inside Promise will help to asynchonously load keys giving better performance